### PR TITLE
Sync stdout so we get metrics to l2met as quickly as possible.

### DIFF
--- a/lib/collective.rb
+++ b/lib/collective.rb
@@ -16,6 +16,7 @@ module Collective
   class << self
     def run
       Metrics.subscribe
+      STDOUT.sync = true
 
       builder = Builder.new
       builder.instance_eval File.read('Collectfile'), __FILE__, __LINE__ - 1


### PR DESCRIPTION
Logplex will buffer appropriately.
