### PR TITLE
Group metrics.

### DIFF
--- a/collective.gemspec
+++ b/collective.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rufus-scheduler',   '~> 2.0'
   spec.add_dependency 'thor',              '~> 0.18'
-  spec.add_dependency 'formatted-metrics', '~> 0.1'
+  spec.add_dependency 'formatted-metrics', ['>= 0.2.1', '< 1.0']
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'

--- a/lib/collective.rb
+++ b/lib/collective.rb
@@ -15,7 +15,6 @@ module Collective
 
   class << self
     def run
-      Metrics.subscribe
       STDOUT.sync = true
 
       builder = Builder.new

--- a/lib/collective/collector.rb
+++ b/lib/collective/collector.rb
@@ -16,5 +16,9 @@ module Collective
     def instrument(*args, &block)
       Metrics.instrument(*args, &block)
     end
+
+    def group(*args, &block)
+      Metrics.group(*args, &block)
+    end
   end
 end

--- a/lib/collective/collectors/memcached.rb
+++ b/lib/collective/collectors/memcached.rb
@@ -3,9 +3,11 @@ module Collective::Collectors
     requires :dalli
 
     collect do
-      client.stats.each do |server, stats|
-        stats.each do |metric, value|
-          instrument "memcached.#{metric}", value, source: server
+      Metrics.group 'memcached' do |group|
+        client.stats.each do |server, stats|
+          stats.each do |metric, value|
+            group.instrument metric, value, source: server
+          end
         end
       end
     end

--- a/lib/collective/collectors/redis.rb
+++ b/lib/collective/collectors/redis.rb
@@ -5,10 +5,12 @@ module Collective::Collectors
     requires :redis
 
     collect do
-      instrument 'redis.used_memory',       (info['used_memory'].to_f / MEGABYTE).round(2)
-      instrument 'redis.connected_clients', info['connected_clients']
-      instrument 'redis.blocked_clients',   info['blocked_clients']
-      instrument 'redis.connected_slaves',  info['connected_slaves']
+      group 'redis' do |group|
+        group.instrument 'used_memory',       (info['used_memory'].to_f / MEGABYTE).round(2)
+        group.instrument 'connected_clients', info['connected_clients']
+        group.instrument 'blocked_clients',   info['blocked_clients']
+        group.instrument 'connected_slaves',  info['connected_slaves']
+      end
     end
 
   private

--- a/lib/collective/collectors/sidekiq.rb
+++ b/lib/collective/collectors/sidekiq.rb
@@ -3,13 +3,15 @@ module Collective::Collectors
     requires :sidekiq
 
     collect do
-      instrument 'sidekiq.queues.processed', stats.processed
-      instrument 'sidekiq.queues.failed',    stats.failed
-      instrument 'sidekiq.queues.enqueued',  stats.enqueued
-      instrument 'sidekiq.workers.busy',     workers
+      group 'sidekiq' do |group|
+        group.instrument 'queues.processed', stats.processed
+        group.instrument 'queues.failed',    stats.failed
+        group.instrument 'queues.enqueued',  stats.enqueued
+        group.instrument 'workers.busy',     workers
 
-      queues.each do |queue, depth|
-        instrument 'sidekiq.queue.enqueued', depth, source: queue
+        queues.each do |queue, depth|
+          group.instrument 'queue.enqueued', depth, source: queue
+        end
       end
     end
 


### PR DESCRIPTION
Produces grouped multi-metrics like this:

```
source=Erics-MacBook-Pro.local.127.0.0.1:11211 measure.memcached.pid=306 measure.memcached.uptime=10936 measure.memcached.time=1375904731 measure.memcached.version=1.4.15 measure.memcached.libevent=2.0.21-stable measure.memcached.pointer_size=64 measure.memcached.rusage_user=0.145808 measure.memcached.rusage_system=0.205689 measure.memcached.curr_connections=16 measure.memcached.total_connections=25 measure.memcached.connection_structures=23 measure.memcached.reserved_fds=20 measure.memcached.cmd_get=0 measure.memcached.cmd_set=0 measure.memcached.cmd_flush=0 measure.memcached.cmd_touch=0 measure.memcached.get_hits=0 measure.memcached.get_misses=0 measure.memcached.delete_misses=0 measure.memcached.delete_hits=0 measure.memcached.incr_misses=0 measure.memcached.incr_hits=0 measure.memcached.decr_misses=0 measure.memcached.decr_hits=0 measure.memcached.cas_misses=0 measure.memcached.cas_hits=0 measure.memcached.cas_badval=0 measure.memcached.touch_hits=0 measure.memcached.touch_misses=0 measure.memcached.auth_cmds=0 measure.memcached.auth_errors=0 measure.memcached.bytes_read=480 measure.memcached.bytes_written=16652 measure.memcached.limit_maxbytes=67108864 measure.memcached.accepting_conns=1 measure.memcached.listen_disabled_num=0 measure.memcached.threads=4 measure.memcached.conn_yields=0 measure.memcached.hash_power_level=16 measure.memcached.hash_bytes=524288 measure.memcached.hash_is_expanding=0 measure.memcached.bytes=0 measure.memcached.curr_items=0 measure.memcached.total_items=0 measure.memcached.expired_unfetched=0 measure.memcached.evicted_unfetched=0 measure.memcached.evictions=0 measure.memcached.reclaimed=0
source=Erics-MacBook-Pro.local measure.sidekiq.queues.processed=1410 measure.sidekiq.queues.failed=189 measure.sidekiq.queues.enqueued=0 measure.sidekiq.workers.busy=0
source=Erics-MacBook-Pro.local.emails measure.sidekiq.queue.enqueued=0
source=Erics-MacBook-Pro.local.deliveries measure.sidekiq.queue.enqueued=0
source=Erics-MacBook-Pro.local.background measure.sidekiq.queue.enqueued=0
source=Erics-MacBook-Pro.local.events measure.sidekiq.queue.enqueued=0
source=Erics-MacBook-Pro.local.messages measure.sidekiq.queue.enqueued=0
source=Erics-MacBook-Pro.local.pusher measure.sidekiq.queue.enqueued=0
```

not sure if long log lines length will be a problem or not, but easy enough to fix in formatted-metrics if it is.
