### PR TITLE
Add a rabbitmq collector.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ It includes collectors for the following:
 * Sidekiq
 * Redis
 * Memcached
+* RabbitMQ (You need to have the management plugin enabled)
 
 ## Installation
 
@@ -37,7 +38,7 @@ Add a Collectfile:
 ```ruby
 use Collective::Collectors::Sidekiq
 use Collective::Collectors::Redis
-use Collective::Collectors::Redis, url: ENV['ROLLOUT_REDIS_URL']
+use Collective::Collectors::RabbitMQ, url: ENV['RABBITMQ_MANAGEMENT_URL']
 ```
 
 Start the collectors.

--- a/collective.gemspec
+++ b/collective.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rufus-scheduler',   '~> 2.0'
   spec.add_dependency 'thor',              '~> 0.18'
   spec.add_dependency 'formatted-metrics', ['>= 0.2.1', '< 2.0']
+  spec.add_dependency 'faraday'
+  spec.add_dependency 'faraday_middleware'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'

--- a/lib/collective.rb
+++ b/lib/collective.rb
@@ -11,6 +11,7 @@ module Collective
     autoload :Sidekiq,   'collective/collectors/sidekiq'
     autoload :Redis,     'collective/collectors/redis'
     autoload :Memcached, 'collective/collectors/memcached'
+    autoload :RabbitMQ,  'collective/collectors/rabbitmq'
   end
 
   class << self

--- a/lib/collective/collectors/rabbitmq.rb
+++ b/lib/collective/collectors/rabbitmq.rb
@@ -1,0 +1,67 @@
+require 'pp'
+
+module Collective::Collectors
+  class RabbitMQ < Collective::Collector
+    requires :faraday
+    requires :faraday_middleware
+    requires :json
+
+    collect do
+      instrument_overview
+      instrument_queues
+    end
+
+  private
+
+    def instrument_overview
+      overview = client.get('overview').body
+
+      group 'rabbitmq' do |group|
+        %w[message_stats object_totals queue_totals].each do |key|
+          group.group key do |group|
+            instrument_hash(group, overview[key])
+          end
+        end
+      end
+    end
+
+    def instrument_queues
+      queues = client.get('queues').body
+
+      group 'rabbitmq.queue' do |group|
+        queues.each do |queue|
+          instrument_hash(group, queue, source: "rabbitmq.queue.#{queue['name']}")
+        end
+      end
+    end
+
+    def instrument_hash(group, hash, options={})
+      hash.each do |key, val|
+        case val
+        when Hash
+          group.group key do |group|
+            instrument_hash(group, val, options)
+          end
+        else
+          group.instrument(key, val, options) if instrumentable?(val)
+        end
+      end
+    end
+
+    def instrumentable?(value)
+      Float(value) rescue nil
+    end
+
+    def client
+      @client ||= Faraday.new(url) do |builder|
+        builder.response :json, content_type: /\bjson$/
+        builder.adapter Faraday.default_adapter
+      end
+    end
+
+    def url
+      options[:url]
+    end
+
+  end
+end


### PR DESCRIPTION
This adds a collector for RabbitMQ. It will collect most of the stats from the `/api/overview` endpoint and the `/api/queues` endpoint of the [management plugin](https://blue-fawn.rmq.cloudamqp.com/api/)
