### PR TITLE
Instrument nodes.

### DIFF
--- a/lib/collective/collectors/rabbitmq.rb
+++ b/lib/collective/collectors/rabbitmq.rb
@@ -7,9 +7,20 @@ module Collective::Collectors
     collect do
       instrument_overview
       instrument_queues
+      instrument_channels
     end
 
   private
+
+    def instrument_channels
+      nodes = client.get('nodes').body
+
+      group 'rabbitmq' do |group|
+        nodes.each do |node|
+          instrument_hash(group, node, source: node['name'])
+        end
+      end
+    end
 
     def instrument_overview
       overview = client.get('overview').body
@@ -34,6 +45,7 @@ module Collective::Collectors
     end
 
     def instrument_hash(group, hash, options={})
+      return unless hash.respond_to?(:each)
       hash.each do |key, val|
         case val
         when Hash


### PR DESCRIPTION
Results in metrics like this:

```
source=eric-macbook-air.local.rabbit@orange-hyena-01 measure#rabbitmq.os_pid=8502
measure#rabbitmq.fd_used=111 measure#rabbitmq.fd_total=16384 measure#rabbitmq.sockets_used=79
measure#rabbitmq.sockets_total=14653 measure#rabbitmq.mem_used=89014440 
measure#rabbitmq.mem_limit=247536025 measure#rabbitmq.disk_free_limit=50000000 
measure#rabbitmq.disk_free=19280224256 measure#rabbitmq.proc_used=542 
measure#rabbitmq.proc_total=1048576 measure#rabbitmq.uptime=6050337205 
measure#rabbitmq.run_queue=0 measure#rabbitmq.processors=1
```
