### PR TITLE
Add PGBouncer collector.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ group :development do
   gem 'dalli'
   gem 'sidekiq'
   gem 'mongoid', '~> 3.0'
+  gem 'pg'
 end

--- a/lib/collective.rb
+++ b/lib/collective.rb
@@ -15,6 +15,7 @@ module Collective
     autoload :Mongodb,     'collective/collectors/mongodb'
     autoload :Honeybadger, 'collective/collectors/honeybadger'
     autoload :Newrelic,    'collective/collectors/newrelic'
+    autoload :PGBouncer,   'collective/collectors/pgbouncer'
   end
 
   class << self

--- a/lib/collective/collectors/pgbouncer.rb
+++ b/lib/collective/collectors/pgbouncer.rb
@@ -1,0 +1,41 @@
+module Collective::Collectors
+  class PGBouncer < Collective::Collector
+    requires :pg
+
+    collect do
+      group 'pgbouncer' do |group|
+        instrument group, 'stats'
+        instrument group, 'pools'
+      end
+    end
+
+  private
+
+    def instrument(group, thing)
+      group.group thing do |group|
+        instrument_tuples group, show(thing)
+      end
+    end
+
+    def show(thing)
+      conn.exec "show #{thing};"
+    end
+
+    def instrument_tuples(group, tuples)
+      tuples.each do |tuple|
+        source = tuple.key?('database') ? tuple['database'] : ''
+        tuple.each do |k,v|
+          group.instrument(k, v, source: source) if instrumentable?(v)
+        end
+      end
+    end
+
+    def conn
+      @conn ||= PG.connect(connection_options)
+    end
+
+    def connection_options
+      (options[:connection] || {}).merge(dbname: 'pgbouncer')
+    end
+  end
+end


### PR DESCRIPTION
Uses the `show pools;`, and `show stats;` [commands available](https://pgbouncer.github.io/usage.html) with pgbouncer when connected to the `pgbouncer` database.

```
source=Erics-MacBook.local.pgbouncer measure#pgbouncer.stats.total_requests=27 source=Erics-MacBook.local.pgbouncer measure#pgbouncer.stats.total_requests=28 measure#pgbouncer.stats.total_received=0 measure#pgbouncer.stats.total_sent=0 measure#pgbouncer.stats.total_query_time=0 measure#pgbouncer.stats.avg_req=0 measure#pgbouncer.stats.avg_recv=0 measure#pgbouncer.stats.avg_sent=0 measure#pgbouncer.stats.avg_query=0 measure#pgbouncer.pools.cl_active=2 measure#pgbouncer.pools.cl_waiting=0 measure#pgbouncer.pools.sv_active=0 measure#pgbouncer.pools.sv_idle=0 measure#pgbouncer.pools.sv_used=0 measure#pgbouncer.pools.sv_tested=0 measure#pgbouncer.pools.sv_login=0 measure#pgbouncer.pools.maxwait=0
source=Erics-MacBook.local.postgres measure#pgbouncer.stats.total_requests=4 measure#pgbouncer.stats.total_received=64 measure#pgbouncer.stats.total_sent=1062 measure#pgbouncer.stats.total_query_time=4861 measure#pgbouncer.stats.avg_req=0 measure#pgbouncer.stats.avg_recv=0 measure#pgbouncer.stats.avg_sent=0 measure#pgbouncer.stats.avg_query=0 measure#pgbouncer.pools.cl_active=0 measure#pgbouncer.pools.cl_waiting=0 measure#pgbouncer.pools.sv_active=0 measure#pgbouncer.pools.sv_idle=0 measure#pgbouncer.pools.sv_used=0 measure#pgbouncer.pools.sv_tested=0 measure#pgbouncer.pools.sv_login=0 measure#pgbouncer.pools.maxwait=0
```