### PR TITLE
New total_disk_usage metric with table tag

### DIFF
--- a/collective.gemspec
+++ b/collective.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rufus-scheduler',   '~> 2.0'
   spec.add_dependency 'thor',              '~> 0.18'
-  spec.add_dependency 'formatted-metrics', ['>= 0.2.1', '< 2.0']
+  spec.add_dependency 'formatted-metrics', ['>= 1.4.0', '< 2.0']
   spec.add_dependency 'faraday'
   spec.add_dependency 'faraday_middleware'
 

--- a/lib/collective/collectors/postgres.rb
+++ b/lib/collective/collectors/postgres.rb
@@ -19,7 +19,8 @@ module Collective::Collectors
         conn = PG.connect(connection_options)
         size_tuples = conn.exec(size_query)
         size_tuples.each do |tuple|
-          group.instrument "#{tuple['relation']}.size", (tuple['total_size'].to_f / MEGABYTE).round(2), units: 'MB'
+          group.instrument "#{tuple['relation']}.size", (tuple['total_size'].to_f / MEGABYTE).round(2), units: 'MiB'
+          group.instrument 'total_disk_usage', (tuple['total_size'].to_f / MEGABYTE).round(2), units: 'MiB', tags: {relation: tuple['relation']}
         end
       ensure
         conn.close if conn != nil


### PR DESCRIPTION
`postgres.api.relation.size`: a size metric for each table.
`postgres.api.total_disk_usage`: a catch-all metric divided by the `relation` tag.