### PR TITLE
Add collector for TrackJS

### DIFF
--- a/Collectfile
+++ b/Collectfile
@@ -4,4 +4,6 @@ use Collective::Collectors::Memcached
 unless ENV['NEWRELIC_API_KEY'].nil? || ENV['NEWRELIC_API_KEY'].empty?
   use Collective::Collectors::Newrelic, api_key: ENV['NEWRELIC_API_KEY'], filter: ENV['NEWRELIC_APPLICATION_FILTER']
 end
-
+unless ENV['TRACKJS_API_KEY'].nil? || ENV['TRACKJS_API_KEY'].empty?
+  use Collective::Collectors::TrackJS, api_key: ENV['TRACKJS_API_KEY'], customer_id: ENV['TRACKJS_CUSTOMER_ID']
+end

--- a/Collectfile
+++ b/Collectfile
@@ -5,5 +5,5 @@ unless ENV['NEWRELIC_API_KEY'].nil? || ENV['NEWRELIC_API_KEY'].empty?
   use Collective::Collectors::Newrelic, api_key: ENV['NEWRELIC_API_KEY'], filter: ENV['NEWRELIC_APPLICATION_FILTER']
 end
 unless ENV['TRACKJS_API_KEY'].nil? || ENV['TRACKJS_API_KEY'].empty?
-  use Collective::Collectors::TrackJS, api_key: ENV['TRACKJS_API_KEY'], customer_id: ENV['TRACKJS_CUSTOMER_ID']
+  use Collective::Collectors::TrackJS, api_key: ENV['TRACKJS_API_KEY'], customer_id: ENV['TRACKJS_CUSTOMER_ID'], applications: ['r101-frontend', 'r101-marketing']
 end

--- a/Collectfile
+++ b/Collectfile
@@ -5,5 +5,5 @@ unless ENV['NEWRELIC_API_KEY'].nil? || ENV['NEWRELIC_API_KEY'].empty?
   use Collective::Collectors::Newrelic, api_key: ENV['NEWRELIC_API_KEY'], filter: ENV['NEWRELIC_APPLICATION_FILTER']
 end
 unless ENV['TRACKJS_API_KEY'].nil? || ENV['TRACKJS_API_KEY'].empty?
-  use Collective::Collectors::TrackJS, api_key: ENV['TRACKJS_API_KEY'], customer_id: ENV['TRACKJS_CUSTOMER_ID'], applications: ['r101-frontend', 'r101-marketing']
+  use Collective::Collectors::TrackJS, api_key: ENV['TRACKJS_API_KEY'], customer_id: ENV['TRACKJS_CUSTOMER_ID']
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,14 +6,15 @@ gemspec
 group :development do
   gem 'dalli'
   gem 'sidekiq'
-  gem 'mongoid', '~> 3.0'
+  gem 'mongoid',       '~> 3.0'
   gem 'pg'
 end
 
 group :development, :test do
-  gem 'rspec',   '~> 3.4.0'
-  gem 'dotenv',  '~> 2.1.1'
+  gem 'rspec',         '~> 3.4.0'
+  gem 'dotenv',        '~> 2.1.1'
   gem 'faker'
+  gem 'activesupport'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,12 @@ group :development do
   gem 'mongoid', '~> 3.0'
   gem 'pg'
 end
+
+group :development, :test do
+  gem 'rspec',   '~> 3.4.0'
+  gem 'dotenv',  '~> 2.1.1'
+end
+
+group :test do
+  gem 'webmock'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ end
 group :development, :test do
   gem 'rspec',   '~> 3.4.0'
   gem 'dotenv',  '~> 2.1.1'
+  gem 'faker'
 end
 
 group :test do

--- a/lib/collective.rb
+++ b/lib/collective.rb
@@ -17,6 +17,7 @@ module Collective
     autoload :Newrelic,    'collective/collectors/newrelic'
     autoload :PGBouncer,   'collective/collectors/pgbouncer'
     autoload :Postgres,    'collective/collectors/postgres'
+    autoload :TrackJS,     'collective/collectors/trackjs'
   end
 
   class << self

--- a/lib/collective/collectors/trackjs.rb
+++ b/lib/collective/collectors/trackjs.rb
@@ -8,8 +8,8 @@ module Collective::Collectors
 
     resolution '60s'
 
-    def initialize(lastSeenId = nil, options)
-      @lastSeenId = lastSeenId
+    def initialize(last_seen_id = nil, options)
+      @last_seen_id = last_seen_id
       super(options)
     end
 
@@ -50,40 +50,40 @@ module Collective::Collectors
     def paged(path, params={})
       Enumerator.new do |yielder|
         page = 1
-        pageSize = 250
-        maxPages = 1
-        currentInitialId = nil
-        getAnotherPage = true # set to true until an error id that has already been seen is hit
+        page_size = 250
+        max_pages = 1
+        current_initial_id = nil
+        get_another_page = true # set to true until an error id that has already been seen is hit
 
-        resp = get_page(path, params, page, pageSize)
+        resp = get_page(path, params, page, page_size)
         data = resp.body['data']
 
         if data.length > 0
-          currentInitialId = data[0]['id']
+          current_initial_id = data[0]['id']
 
-          while page <= maxPages do
+          while page <= max_pages do
             resp.body['data'].each do |error|
-              if error['id'] == @lastSeenId
-                getAnotherPage = false
+              if error['id'] == @last_seen_id
+                get_another_page = false
                 break
               else
                 yielder.yield error
               end
             end
 
-            break if !getAnotherPage or !resp.body['metadata']['hasMore']
+            break if !get_another_page or !resp.body['metadata']['hasMore']
 
             page += 1
-            resp = get_page(path, params, page, pageSize)
+            resp = get_page(path, params, page, page_size)
           end
 
-          @lastSeenId = currentInitialId
+          @last_seen_id = current_initial_id
         end
       end
     end
 
-    def get_page(path, params, page, pageSize = 500)
-      client.get(path, params.merge(page: page, size: pageSize)) do |req|
+    def get_page(path, params, page, page_size = 500)
+      client.get(path, params.merge(page: page, size: page_size)) do |req|
         req.headers['Authorization'] = api_key
       end
     end

--- a/lib/collective/collectors/trackjs.rb
+++ b/lib/collective/collectors/trackjs.rb
@@ -8,7 +8,7 @@ module Collective::Collectors
 
     resolution '60s'
 
-    def initialize(last_seen_id = nil, options)
+    def initialize(last_seen_id = {}, options)
       @last_seen_id = last_seen_id
       super(options)
     end
@@ -53,6 +53,7 @@ module Collective::Collectors
         max_pages = 1
         current_initial_id = nil
         get_another_page = true # set to true until an error id that has already been seen is hit
+        application = params[:application]
 
         resp = get_page(path, params, page, page_size)
         data = resp.body['data']
@@ -62,7 +63,7 @@ module Collective::Collectors
 
           while page <= max_pages do
             resp.body['data'].each do |error|
-              if error['id'] == @last_seen_id
+              if error['id'] == @last_seen_id[application]
                 get_another_page = false
                 break
               else
@@ -76,7 +77,7 @@ module Collective::Collectors
             resp = get_page(path, params, page, page_size)
           end
 
-          @last_seen_id = current_initial_id
+          @last_seen_id[application] = current_initial_id
         end
       end
     end

--- a/lib/collective/collectors/trackjs.rb
+++ b/lib/collective/collectors/trackjs.rb
@@ -8,49 +8,107 @@ module Collective::Collectors
 
     resolution '60s'
 
-    # def initialize(mostRecentId = nil, options = {})
-    #   @mostRecentId = mostRecentId
-    #   @options = options
-    # end
+    def initialize(lastSeenId = nil, options)
+      @lastSeenId = lastSeenId
+      super(options)
+    end
 
     collect do
+      p "COLLECT@@@@@@@@@@@@@@@@@@@@@@@"
       instrument_errors
     end
 
     private
 
     def instrument_errors
-      paged("/#{customer_id}/v1/errors").each do |resp|
-        p "resp"
-        pp resp
-        # p "most recent id"
-        # pp mostRecentId
-        errors = resp.body['data']
-
-        errors.each do |error|
-          instrument 'trackjs.url.errors', error['count'], source: error['key'], type: 'count'
-        end
+      paged("/#{customer_id}/v1/errors").each do |error|
+        p "tracking an error"
+        p "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr"
+        # p error
+        # errors.each do |error|
+        #   instrument 'trackjs.url.errors', error['count'], source: error['key'], type: 'count'
+        # end
       end
     end
 
-    # TODO: test paging
     def paged(path, params={})
       Enumerator.new do |yielder|
         page = 1
-        pageSize = 500
+        pageSize = 10
+        maxPages = 3
         resp = get_page(path, params, page, pageSize)
+        currentStartId = nil # TODO: better variable name
+        getAnotherPage = true
 
-        # TODO: test response handling
-        while page < 2 do # resp.body['metadata']['hasMore'] == true do
-          yielder.yield resp.body['data'] # pull out each error automatically?
-          # @mostRecentId = page
-          page += 1
-          resp = get_page(path, params, page)
+        # p "response data"
+        # p resp.body['data']
+        p "response metadata"
+        p resp.body['metadata']
+        p "@lastSeenId"
+        p @lastSeenId
+        p "************************************************"
+
+        data = resp.body['data']
+        # TODO: add documentation about what we're doing to handle the fact
+        # that trackjs only lets you get data at a minimum granularity of 1
+        # day.
+        if data.length
+          # p "data[0]"
+          # p data[0]
+          # p "data[0].id"
+          # p data[0]['id']
+          currentStartId = data[0]['id']
+          p "storing most recent Id:"
+          p currentStartId
+          p "************************************************"
+
+          # This will loop over every single event ever the first time it's run
+          # if it's not constrained somehow
+          while resp.body['metadata']['hasMore'] == true and page <= maxPages do # page < 3 do # resp.body['metadata']['hasMore'] == true do
+            resp.body['data'].each do |error|
+              p "error"
+              p error['message']
+              p error['id']
+              if error['id'] == @lastSeenId
+                p "BREAKING OUT OF LOOP. I'VE SEEN THIS ERROR BEFORE"
+                getAnotherPage = false
+                break
+              else
+                yielder.yield error
+              end
+            end
+
+            if getAnotherPage
+              p ">>>going to get another page"
+              page += 1
+              resp = get_page(path, params, page, pageSize)
+            else
+              break
+            end
+          end
+          # check why i broke out of the while loop
+          # options:
+          # hit something i'd seen before
+          # hit the very end of the errors list
+          # hit the max page limit
+          if getAnotherPage == false
+            p "1111111 Finished while loop because I saw an error i'd seen before"
+          elsif page > maxPages
+            p "2222222 Finished while loop because I hit the max page limit"
+          else
+            p "3333333 Finished while loop because I hit the end of the errors list"
+          end
+          p "setting last seen id to"
+          p currentStartId
+          @lastSeenId = currentStartId
         end
       end
     end
 
-    def get_page(path, params, page, pageSize)
+    def get_page(path, params, page, pageSize = 500)
+      p "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!>>>>>>>>>>>>"
+      p "getting a new page of results"
+      p "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!>>>>>>>>>>>>"
       client.get(path, params.merge(page: page, size: pageSize)) do |req|
         req.headers['Authorization'] = api_key
       end

--- a/lib/collective/collectors/trackjs.rb
+++ b/lib/collective/collectors/trackjs.rb
@@ -61,7 +61,7 @@ module Collective::Collectors
         if data.length > 0
           currentInitialId = data[0]['id']
 
-          while resp.body['metadata']['hasMore'] == true and page <= maxPages do
+          while page <= maxPages do
             resp.body['data'].each do |error|
               if error['id'] == @lastSeenId
                 getAnotherPage = false
@@ -71,7 +71,7 @@ module Collective::Collectors
               end
             end
 
-            break if !getAnotherPage
+            break if !getAnotherPage or !resp.body['metadata']['hasMore']
 
             page += 1
             resp = get_page(path, params, page, pageSize)

--- a/lib/collective/collectors/trackjs.rb
+++ b/lib/collective/collectors/trackjs.rb
@@ -21,14 +21,20 @@ module Collective::Collectors
     private
 
     def instrument_errors
+      count = 0
+      application = ""
       paged("/#{customer_id}/v1/errors").each do |error|
         p "tracking an error"
         p "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr"
+        application = error['application'] if count == 0
+        count += 1
         # p error
         # errors.each do |error|
         #   instrument 'trackjs.url.errors', error['count'], source: error['key'], type: 'count'
         # end
       end
+      p "LOGGING #{count} errors to the collector for application #{application}"
+      instrument 'trackjs.url.errors', count, source: application, type: 'count'
     end
 
     # This function goes through a paged list of errors and yields each

--- a/lib/collective/collectors/trackjs.rb
+++ b/lib/collective/collectors/trackjs.rb
@@ -57,8 +57,8 @@ module Collective::Collectors
         pageSize = 10
         maxPages = 3
         resp = get_page(path, params, page, pageSize)
-        getAnotherPage = true
         currentInitialId = nil
+        getAnotherPage = true # set to true until an error id that has already been seen is hit
 
         p "response metadata"
         p resp.body['metadata']

--- a/lib/collective/collectors/trackjs.rb
+++ b/lib/collective/collectors/trackjs.rb
@@ -54,8 +54,8 @@ module Collective::Collectors
     def paged(path, params={})
       Enumerator.new do |yielder|
         page = 1
-        pageSize = 10
-        maxPages = 3
+        pageSize = 250
+        maxPages = 1
         resp = get_page(path, params, page, pageSize)
         currentInitialId = nil
         getAnotherPage = true # set to true until an error id that has already been seen is hit

--- a/lib/collective/collectors/trackjs.rb
+++ b/lib/collective/collectors/trackjs.rb
@@ -1,0 +1,78 @@
+require 'pp'
+
+module Collective::Collectors
+  class TrackJS < Collective::Collector
+    requires :faraday
+    requires :faraday_middleware
+    requires :json
+
+    resolution '60s'
+
+    # def initialize(mostRecentId = nil, options = {})
+    #   @mostRecentId = mostRecentId
+    #   @options = options
+    # end
+
+    collect do
+      instrument_errors
+    end
+
+    private
+
+    def instrument_errors
+      paged("/#{customer_id}/v1/errors").each do |resp|
+        p "resp"
+        pp resp
+        # p "most recent id"
+        # pp mostRecentId
+        errors = resp.body['data']
+
+        errors.each do |error|
+          instrument 'trackjs.url.errors', error['count'], source: error['key'], type: 'count'
+        end
+      end
+    end
+
+    # TODO: test paging
+    def paged(path, params={})
+      Enumerator.new do |yielder|
+        page = 1
+        pageSize = 500
+        resp = get_page(path, params, page, pageSize)
+
+        # TODO: test response handling
+        while page < 2 do # resp.body['metadata']['hasMore'] == true do
+          yielder.yield resp.body['data'] # pull out each error automatically?
+          # @mostRecentId = page
+          page += 1
+          resp = get_page(path, params, page)
+        end
+      end
+    end
+
+    def get_page(path, params, page, pageSize)
+      client.get(path, params.merge(page: page, size: pageSize)) do |req|
+        req.headers['Authorization'] = api_key
+      end
+    end
+
+    def client
+      @client ||= Faraday.new(api_url) do |builder|
+        builder.response :json, content_type: /\bjson$/
+        builder.adapter Faraday.default_adapter
+      end
+    end
+
+    def api_url
+      "https://api.trackjs.com"
+    end
+
+    def customer_id
+      options[:customer_id]
+    end
+
+    def api_key
+      options[:api_key]
+    end
+  end
+end

--- a/lib/collective/collectors/trackjs.rb
+++ b/lib/collective/collectors/trackjs.rb
@@ -14,16 +14,15 @@ module Collective::Collectors
     end
 
     collect do
-      instrument_errors
+      instrument_errors "r101-frontend"
+      instrument_errors "r101-marketing"
     end
 
     private
 
-    def instrument_errors
+    def instrument_errors(application)
       count = 0
-      application = ""
-      paged("/#{customer_id}/v1/errors").each do |error|
-        application = error['application'] if count == 0
+      paged("/#{customer_id}/v1/errors", {application: application}).each do |error|
         count += 1
       end
       instrument 'trackjs.url.errors', count, source: application, type: 'count'

--- a/lib/collective/collectors/trackjs.rb
+++ b/lib/collective/collectors/trackjs.rb
@@ -31,6 +31,24 @@ module Collective::Collectors
       end
     end
 
+    # This function goes through a paged list of errors and yields each
+    # individual error.
+    #
+    # The most basic endpoint in the TrackJS API returns all the errors that
+    # have been detected from the beginning of time to the current date. This
+    # endpoint can return the number of errors seen in the last day, but since
+    # we're just trying to determine the number of errors that occurred in the
+    # last 60s, we use the default endpoint options.
+    #
+    # To avoid fetching all the errors, only the ones we haven't seen since
+    # the last time we checked, so we keep track of the id of the last error
+    # we saw and page through the error list until either:
+    #
+    # 1. We see an error we've already returned
+    # 2. We hit a maximum page limit (to avoid scanning the entire list of
+    #    errors the first time the collector is run)
+    # 3. We hit the very end of the error list
+    #
     def paged(path, params={})
       Enumerator.new do |yielder|
         page = 1

--- a/lib/collective/collectors/trackjs.rb
+++ b/lib/collective/collectors/trackjs.rb
@@ -8,8 +8,8 @@ module Collective::Collectors
 
     resolution '60s'
 
-    def initialize(last_seen_id = {}, options)
-      @last_seen_id = last_seen_id
+    def initialize(options = {})
+      @last_seen_id = options[:last_seen_id]
       super(options)
     end
 

--- a/lib/collective/collectors/trackjs.rb
+++ b/lib/collective/collectors/trackjs.rb
@@ -1,5 +1,3 @@
-require 'pp'
-
 module Collective::Collectors
   class TrackJS < Collective::Collector
     requires :faraday
@@ -15,8 +13,9 @@ module Collective::Collectors
     end
 
     collect do
-      instrument_errors "r101-frontend"
-      instrument_errors "r101-marketing"
+      options[:applications].each do |application|
+        instrument_errors application
+      end
     end
 
     private

--- a/lib/collective/collectors/trackjs.rb
+++ b/lib/collective/collectors/trackjs.rb
@@ -28,10 +28,6 @@ module Collective::Collectors
         p "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr"
         application = error['application'] if count == 0
         count += 1
-        # p error
-        # errors.each do |error|
-        #   instrument 'trackjs.url.errors', error['count'], source: error['key'], type: 'count'
-        # end
       end
       p "LOGGING #{count} errors to the collector for application #{application}"
       instrument 'trackjs.url.errors', count, source: application, type: 'count'
@@ -61,11 +57,9 @@ module Collective::Collectors
         pageSize = 10
         maxPages = 3
         resp = get_page(path, params, page, pageSize)
-        currentStartId = nil # TODO: better variable name
         getAnotherPage = true
+        currentInitialId = nil
 
-        # p "response data"
-        # p resp.body['data']
         p "response metadata"
         p resp.body['metadata']
         p "@lastSeenId"
@@ -73,22 +67,13 @@ module Collective::Collectors
         p "************************************************"
 
         data = resp.body['data']
-        # TODO: add documentation about what we're doing to handle the fact
-        # that trackjs only lets you get data at a minimum granularity of 1
-        # day.
         if data.length
-          # p "data[0]"
-          # p data[0]
-          # p "data[0].id"
-          # p data[0]['id']
-          currentStartId = data[0]['id']
+          currentInitialId = data[0]['id']
           p "storing most recent Id:"
-          p currentStartId
+          p currentInitialId
           p "************************************************"
 
-          # This will loop over every single event ever the first time it's run
-          # if it's not constrained somehow
-          while resp.body['metadata']['hasMore'] == true and page <= maxPages do # page < 3 do # resp.body['metadata']['hasMore'] == true do
+          while resp.body['metadata']['hasMore'] == true and page <= maxPages do
             resp.body['data'].each do |error|
               p "error"
               p error['message']
@@ -123,8 +108,8 @@ module Collective::Collectors
             p "3333333 Finished while loop because I hit the end of the errors list"
           end
           p "setting last seen id to"
-          p currentStartId
-          @lastSeenId = currentStartId
+          p currentInitialId
+          @lastSeenId = currentInitialId
         end
       end
     end

--- a/lib/collective/collectors/trackjs.rb
+++ b/lib/collective/collectors/trackjs.rb
@@ -58,7 +58,7 @@ module Collective::Collectors
         resp = get_page(path, params, page, pageSize)
         data = resp.body['data']
 
-        if data.length
+        if data.length > 0
           currentInitialId = data[0]['id']
 
           while resp.body['metadata']['hasMore'] == true and page <= maxPages do

--- a/lib/collective/collectors/trackjs.rb
+++ b/lib/collective/collectors/trackjs.rb
@@ -87,13 +87,10 @@ module Collective::Collectors
               end
             end
 
-            if getAnotherPage
-              p ">>>going to get another page"
-              page += 1
-              resp = get_page(path, params, page, pageSize)
-            else
-              break
-            end
+            break if !getAnotherPage
+
+            page += 1
+            resp = get_page(path, params, page, pageSize)
           end
           # check why i broke out of the while loop
           # options:

--- a/spec/lib/collective/collectors/trackjs_spec.rb
+++ b/spec/lib/collective/collectors/trackjs_spec.rb
@@ -16,7 +16,7 @@ describe Collective::Collectors::TrackJS do
 
   context 'when no errors are returned' do
     let(:errors) { 0 }
-    let(:response) { trackjs_response errors, errors, page, page_size }
+    let(:response) { trackjs_response errors: errors, total_errors: errors, page: page, page_size: page_size }
 
     it 'logs an error count of 0' do
       stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
@@ -37,7 +37,7 @@ describe Collective::Collectors::TrackJS do
 
   context 'when less than a page of errors are returned' do
     let(:errors) { 45 }
-    let(:response) { trackjs_response errors, errors, page, page_size }
+    let(:response) { trackjs_response errors: errors, total_errors: errors, page: page, page_size: page_size }
 
     context 'when none of the errors have been logged before' do
       it 'logs all the errors returned' do
@@ -63,8 +63,8 @@ describe Collective::Collectors::TrackJS do
       let(:old_errors) { old_error_count.times.map { trackjs_error } }
       let(:new_errors) { new_error_count.times.map { trackjs_error } }
       let(:all_errors) { new_errors + old_errors }
-      let(:old_metadata) { trackjs_metadata old_error_count, page, page_size, false }
-      let(:new_metadata) { trackjs_metadata (old_error_count + new_error_count), page, page_size, false }
+      let(:old_metadata) { trackjs_metadata total_count: old_error_count, page: page, page_size: page_size, has_more: false }
+      let(:new_metadata) { trackjs_metadata total_count: (old_error_count + new_error_count), page: page, page_size: page_size, has_more: false }
       let(:old_response) { {"data" => old_errors, "metadata" => old_metadata} }
       let(:new_response) { {"data" => all_errors, "metadata" => new_metadata} }
 
@@ -103,8 +103,8 @@ describe Collective::Collectors::TrackJS do
     let(:page2) { 2 }
 
     context 'none of the errors have been logged before' do
-      let(:response) { trackjs_response old_error_count, total_errors, page, page_size }
-      let(:response2) { trackjs_response old_error_count, total_errors, page2, page_size }
+      let(:response) { trackjs_response errors: old_error_count, total_errors: total_errors, page: page, page_size: page_size }
+      let(:response2) { trackjs_response errors: old_error_count, total_errors: total_errors, page: page2, page_size: page_size }
 
       it 'logs maxPage * page size errors' do
         stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
@@ -134,8 +134,8 @@ describe Collective::Collectors::TrackJS do
       let(:old_errors) { old_error_count.times.map { trackjs_error } }
       let(:new_errors) { new_error_count.times.map { trackjs_error } }
       let(:combined_errors) { (new_errors + old_errors).first page_size }
-      let(:old_metadata) { trackjs_metadata old_error_count, page, page_size, true }
-      let(:combined_metadata) { trackjs_metadata (old_error_count + new_error_count), page, page_size, true }
+      let(:old_metadata) { trackjs_metadata total_count: old_error_count, page: page, page_size: page_size, has_more: true }
+      let(:combined_metadata) { trackjs_metadata total_count: (old_error_count + new_error_count), page: page, page_size: page_size, has_more: true }
       let(:old_response) { {"data" => old_errors, "metadata" => old_metadata } }
       let(:combined_response) { {"data" => combined_errors, "metadata" => combined_metadata } }
 

--- a/spec/lib/collective/collectors/trackjs_spec.rb
+++ b/spec/lib/collective/collectors/trackjs_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'collective'
+
+describe Collective::Collectors::TrackJS do
+  let(:env_api_key) { ENV["TRACKJS_API_KEY"] }
+  let(:env_customer_id) { ENV["TRACKJS_CUSTOMER_ID"] }
+
+  before do
+    @collector = Collective::Collectors::TrackJS.new nil, {
+      :api_key => env_api_key,
+      :customer_id => env_customer_id
+    }
+  end
+
+  context 'when no errors are returned' do
+    let(:errors) { 0 }
+    let(:page) { 1 }
+    let(:page_size) { 250 }
+    let(:has_more) { false }
+    let(:response) { trackjs_response errors, page, page_size, has_more }
+
+    fit 'logs an error count of 0' do
+      stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
+        .with(:query => {"page" => page, "size" => page_size})
+        .to_return(:body => response.to_s, :status => 200)
+
+      expect { @collector.collect }.to output('/count=0/').to_stdout
+      expect(
+        a_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors").with(:query => {"page" => page, "size" => page_size})
+      ).to have_been_made
+    end
+  end
+
+  context 'when we try and use the collect function' do
+    let!(:metadata) { trackjs_metadata }
+    let!(:resp) { trackjs_response 2 }
+
+    it 'does stuff (test test)' do
+      # expect(Collective::Collector).to receive(:instrument)
+      @collector.collect
+      p "trackjs metadata"
+      pp metadata
+      p "trackjs response"
+      pp resp
+    end
+  end
+end

--- a/spec/lib/collective/collectors/trackjs_spec.rb
+++ b/spec/lib/collective/collectors/trackjs_spec.rb
@@ -16,32 +16,119 @@ describe Collective::Collectors::TrackJS do
     let(:errors) { 0 }
     let(:page) { 1 }
     let(:page_size) { 250 }
-    let(:has_more) { false }
-    let(:response) { trackjs_response errors, page, page_size, has_more }
+    let(:response) { trackjs_response errors, errors, page, page_size }
 
-    fit 'logs an error count of 0' do
+    it 'logs an error count of 0' do
       stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
         .with(:query => {"page" => page, "size" => page_size})
-        .to_return(:body => response.to_s, :status => 200)
+        .to_return(
+          :body => response.to_json,
+          :status => 200,
+          :headers => {'Content-Type' => 'application/json'}
+        )
 
-      expect { @collector.collect }.to output('/count=0/').to_stdout
+      expect(Metrics).to receive(:instrument).with('trackjs.url.errors', 0, any_args)
+      @collector.collect
       expect(
         a_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors").with(:query => {"page" => page, "size" => page_size})
       ).to have_been_made
     end
   end
 
-  context 'when we try and use the collect function' do
-    let!(:metadata) { trackjs_metadata }
-    let!(:resp) { trackjs_response 2 }
+  context 'when less than a page of errors are returned' do
+    let(:errors) { 45 }
+    let(:page) { 1 }
+    let(:page_size) { 250 }
+    let(:response) { trackjs_response errors, errors, page, page_size }
 
-    it 'does stuff (test test)' do
-      # expect(Collective::Collector).to receive(:instrument)
+    it 'logs all the errors returned' do
+      stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
+        .with(:query => {"page" => page, "size" => page_size})
+        .to_return(
+          :body => response.to_json,
+          :status => 200,
+          :headers => {'Content-Type' => 'application/json'}
+        )
+
+      expect(Metrics).to receive(:instrument).with('trackjs.url.errors', 45, any_args)
       @collector.collect
-      p "trackjs metadata"
-      pp metadata
-      p "trackjs response"
-      pp resp
+      expect(
+        a_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors").with(:query => {"page" => page, "size" => page_size})
+      ).to have_been_made
+    end
+  end
+
+  context 'when more than maxPages pages of errors are returned' do
+    let(:errors) { 250 }
+    let(:total_errors) { 800 }
+    let(:page) { 1 }
+    let(:page2) { 2 }
+    let(:page_size) { 250 }
+
+    context 'none of the errors have been logged before' do
+      let(:response) { trackjs_response errors, total_errors, page, page_size }
+      let(:response2) { trackjs_response errors, total_errors, page2, page_size }
+
+      it 'logs maxPage * page size errors' do
+        stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
+          .with(:query => {"page" => page, "size" => page_size})
+          .to_return(
+            :body => response.to_json,
+            :status => 200,
+            :headers => {'Content-Type' => 'application/json'}
+          )
+        stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
+          .with(:query => {"page" => page2, "size" => page_size})
+          .to_return(
+            :body => response2.to_json,
+            :status => 200,
+            :headers => {'Content-Type' => 'application/json'}
+          )
+
+        expect(Metrics).to receive(:instrument).with('trackjs.url.errors', page_size, any_args)
+        @collector.collect
+        expect(
+          a_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors").with(:query => {"page" => page, "size" => page_size})
+        ).to have_been_made.times(1)
+      end
+    end
+
+    context 'some of the errors have been logged before' do
+      let(:old_error_count) { 5 }
+      let(:new_error_count) { 3 }
+      let(:old_errors) { old_error_count.times.map { trackjs_error } }
+      let(:new_errors) { new_error_count.times.map { trackjs_error } }
+      let(:all_errors) { new_errors + old_errors }
+      let(:old_metadata) { trackjs_metadata old_error_count, page, page_size, false }
+      let(:new_metadata) { trackjs_metadata (old_error_count + new_error_count), page, page_size, false }
+      let(:old_response) { {"data" => old_errors, "metadata" => old_metadata} }
+      let(:new_response) { {"data" => all_errors, "metadata" => new_metadata} }
+
+      before do
+        stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
+          .with(:query => {"page" => page, "size" => page_size})
+          .to_return(
+            :body => old_response.to_json,
+            :status => 200,
+            :headers => {'Content-Type' => 'application/json'}
+          )
+        @collector.collect
+      end
+
+      it 'logs only the errors that have occurred since the last time logging occurred' do
+        stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
+          .with(:query => {"page" => page, "size" => page_size})
+          .to_return(
+            :body => new_response.to_json,
+            :status => 200,
+            :headers => {'Content-Type' => 'application/json'}
+          )
+        expect(Metrics).to receive(:instrument).with('trackjs.url.errors', new_errors.length, any_args)
+        @collector.collect
+        expect(
+          a_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors").with(:query => {"page" => page, "size" => page_size})
+        ).to have_been_made.times(2)
+      end
     end
   end
 end

--- a/spec/lib/collective/collectors/trackjs_spec.rb
+++ b/spec/lib/collective/collectors/trackjs_spec.rb
@@ -12,7 +12,6 @@ describe Collective::Collectors::TrackJS do
 
   before do
     @collector = Collective::Collectors::TrackJS.new(
-      :last_seen_id => {},
       :api_key => env_api_key,
       :customer_id => env_customer_id
     )

--- a/spec/lib/collective/collectors/trackjs_spec.rb
+++ b/spec/lib/collective/collectors/trackjs_spec.rb
@@ -4,6 +4,8 @@ require 'collective'
 describe Collective::Collectors::TrackJS do
   let(:env_api_key) { ENV["TRACKJS_API_KEY"] }
   let(:env_customer_id) { ENV["TRACKJS_CUSTOMER_ID"] }
+  let(:page_size) { 250 }
+  let(:page) { 1 }
 
   before do
     @collector = Collective::Collectors::TrackJS.new nil, {
@@ -14,8 +16,6 @@ describe Collective::Collectors::TrackJS do
 
   context 'when no errors are returned' do
     let(:errors) { 0 }
-    let(:page) { 1 }
-    let(:page_size) { 250 }
     let(:response) { trackjs_response errors, errors, page, page_size }
 
     it 'logs an error count of 0' do
@@ -37,37 +37,74 @@ describe Collective::Collectors::TrackJS do
 
   context 'when less than a page of errors are returned' do
     let(:errors) { 45 }
-    let(:page) { 1 }
-    let(:page_size) { 250 }
     let(:response) { trackjs_response errors, errors, page, page_size }
 
-    it 'logs all the errors returned' do
-      stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
-        .with(:query => {"page" => page, "size" => page_size})
-        .to_return(
-          :body => response.to_json,
-          :status => 200,
-          :headers => {'Content-Type' => 'application/json'}
-        )
+    context 'when none of the errors have been logged before' do
+      it 'logs all the errors returned' do
+        stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
+          .with(:query => {"page" => page, "size" => page_size})
+          .to_return(
+            :body => response.to_json,
+            :status => 200,
+            :headers => {'Content-Type' => 'application/json'}
+          )
 
-      expect(Metrics).to receive(:instrument).with('trackjs.url.errors', 45, any_args)
-      @collector.collect
-      expect(
-        a_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors").with(:query => {"page" => page, "size" => page_size})
-      ).to have_been_made
+        expect(Metrics).to receive(:instrument).with('trackjs.url.errors', 45, any_args)
+        @collector.collect
+        expect(
+          a_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors").with(:query => {"page" => page, "size" => page_size})
+        ).to have_been_made
+      end
+    end
+
+    context 'some of the errors have been logged before' do
+      let(:old_error_count) { 5 }
+      let(:new_error_count) { 3 }
+      let(:old_errors) { old_error_count.times.map { trackjs_error } }
+      let(:new_errors) { new_error_count.times.map { trackjs_error } }
+      let(:all_errors) { new_errors + old_errors }
+      let(:old_metadata) { trackjs_metadata old_error_count, page, page_size, false }
+      let(:new_metadata) { trackjs_metadata (old_error_count + new_error_count), page, page_size, false }
+      let(:old_response) { {"data" => old_errors, "metadata" => old_metadata} }
+      let(:new_response) { {"data" => all_errors, "metadata" => new_metadata} }
+
+      before do
+        stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
+          .with(:query => {"page" => page, "size" => page_size})
+          .to_return(
+            :body => old_response.to_json,
+            :status => 200,
+            :headers => {'Content-Type' => 'application/json'}
+          )
+        @collector.collect
+      end
+
+      it 'logs only the errors that have occurred since the last time logging happened' do
+        stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
+          .with(:query => {"page" => page, "size" => page_size})
+          .to_return(
+            :body => new_response.to_json,
+            :status => 200,
+            :headers => {'Content-Type' => 'application/json'}
+          )
+        expect(Metrics).to receive(:instrument).with('trackjs.url.errors', new_errors.length, any_args)
+        @collector.collect
+        expect(
+          a_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors").with(:query => {"page" => page, "size" => page_size})
+        ).to have_been_made.times(2)
+      end
     end
   end
 
   context 'when more than maxPages pages of errors are returned' do
-    let(:errors) { 250 }
+    let(:old_error_count) { 250 }
+    let(:new_error_count) { 50 }
     let(:total_errors) { 800 }
-    let(:page) { 1 }
     let(:page2) { 2 }
-    let(:page_size) { 250 }
 
     context 'none of the errors have been logged before' do
-      let(:response) { trackjs_response errors, total_errors, page, page_size }
-      let(:response2) { trackjs_response errors, total_errors, page2, page_size }
+      let(:response) { trackjs_response old_error_count, total_errors, page, page_size }
+      let(:response2) { trackjs_response old_error_count, total_errors, page2, page_size }
 
       it 'logs maxPage * page size errors' do
         stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
@@ -94,15 +131,13 @@ describe Collective::Collectors::TrackJS do
     end
 
     context 'some of the errors have been logged before' do
-      let(:old_error_count) { 5 }
-      let(:new_error_count) { 3 }
       let(:old_errors) { old_error_count.times.map { trackjs_error } }
       let(:new_errors) { new_error_count.times.map { trackjs_error } }
-      let(:all_errors) { new_errors + old_errors }
-      let(:old_metadata) { trackjs_metadata old_error_count, page, page_size, false }
-      let(:new_metadata) { trackjs_metadata (old_error_count + new_error_count), page, page_size, false }
-      let(:old_response) { {"data" => old_errors, "metadata" => old_metadata} }
-      let(:new_response) { {"data" => all_errors, "metadata" => new_metadata} }
+      let(:combined_errors) { (new_errors + old_errors).first page_size }
+      let(:old_metadata) { trackjs_metadata old_error_count, page, page_size, true }
+      let(:combined_metadata) { trackjs_metadata (old_error_count + new_error_count), page, page_size, true }
+      let(:old_response) { {"data" => old_errors, "metadata" => old_metadata } }
+      let(:combined_response) { {"data" => combined_errors, "metadata" => combined_metadata } }
 
       before do
         stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
@@ -112,14 +147,21 @@ describe Collective::Collectors::TrackJS do
             :status => 200,
             :headers => {'Content-Type' => 'application/json'}
           )
+        stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
+          .with(:query => {"page" => page2, "size" => page_size})
+          .to_return(
+            :body => old_response.to_json,
+            :status => 200,
+            :headers => {'Content-Type' => 'application/json'}
+          )
         @collector.collect
       end
 
-      it 'logs only the errors that have occurred since the last time logging occurred' do
+      it 'logs only the errors that have occurred since the last time logging happened' do
         stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
           .with(:query => {"page" => page, "size" => page_size})
           .to_return(
-            :body => new_response.to_json,
+            :body => combined_response.to_json,
             :status => 200,
             :headers => {'Content-Type' => 'application/json'}
           )

--- a/spec/lib/collective/collectors/trackjs_spec.rb
+++ b/spec/lib/collective/collectors/trackjs_spec.rb
@@ -6,12 +6,15 @@ describe Collective::Collectors::TrackJS do
   let(:env_customer_id) { ENV["TRACKJS_CUSTOMER_ID"] }
   let(:page_size) { 250 }
   let(:page) { 1 }
+  let(:no_errors) { 0 }
+  let(:empty_response) { trackjs_response errors: no_errors, total_errors: no_errors, page: page, page_size: page_size }
 
   before do
-    @collector = Collective::Collectors::TrackJS.new nil, {
+    @collector = Collective::Collectors::TrackJS.new(
+      :last_seen_id => {},
       :api_key => env_api_key,
       :customer_id => env_customer_id
-    }
+    )
   end
 
   context 'when no errors are returned' do
@@ -62,7 +65,7 @@ describe Collective::Collectors::TrackJS do
         stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
           .with(:query => {"page" => page, "size" => page_size, "application" => "r101-marketing"})
           .to_return(
-            :body => response.to_json,
+            :body => empty_response.to_json,
             :status => 200,
             :headers => {'Content-Type' => 'application/json'}
           )
@@ -101,7 +104,7 @@ describe Collective::Collectors::TrackJS do
         stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
           .with(:query => {"page" => page, "size" => page_size, "application" => "r101-marketing"})
           .to_return(
-            :body => old_response.to_json,
+            :body => empty_response.to_json,
             :status => 200,
             :headers => {'Content-Type' => 'application/json'}
           )
@@ -120,7 +123,7 @@ describe Collective::Collectors::TrackJS do
         stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
           .with(:query => {"page" => page, "size" => page_size, "application" => "r101-marketing"})
           .to_return(
-            :body => new_response.to_json,
+            :body => empty_response.to_json,
             :status => 200,
             :headers => {'Content-Type' => 'application/json'}
           )
@@ -159,7 +162,7 @@ describe Collective::Collectors::TrackJS do
         stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
           .with(:query => {"page" => page, "size" => page_size, "application" => "r101-marketing"})
           .to_return(
-            :body => response.to_json,
+            :body => empty_response.to_json,
             :status => 200,
             :headers => {'Content-Type' => 'application/json'}
           )
@@ -173,7 +176,7 @@ describe Collective::Collectors::TrackJS do
         stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
           .with(:query => {"page" => page2, "size" => page_size, "application" => "r101-marketing"})
           .to_return(
-            :body => response2.to_json,
+            :body => empty_response.to_json,
             :status => 200,
             :headers => {'Content-Type' => 'application/json'}
           )
@@ -210,7 +213,7 @@ describe Collective::Collectors::TrackJS do
         stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
           .with(:query => {"page" => page, "size" => page_size, "application" => "r101-marketing"})
           .to_return(
-            :body => old_response.to_json,
+            :body => empty_response.to_json,
             :status => 200,
             :headers => {'Content-Type' => 'application/json'}
           )
@@ -224,7 +227,7 @@ describe Collective::Collectors::TrackJS do
         stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
           .with(:query => {"page" => page2, "size" => page_size, "application" => "r101-marketing"})
           .to_return(
-            :body => old_response.to_json,
+            :body => empty_response.to_json,
             :status => 200,
             :headers => {'Content-Type' => 'application/json'}
           )
@@ -242,7 +245,7 @@ describe Collective::Collectors::TrackJS do
         stub_request(:get, "https://api.trackjs.com/#{env_customer_id}/v1/errors")
           .with(:query => {"page" => page, "size" => page_size, "application" => "r101-marketing"})
           .to_return(
-            :body => combined_response.to_json,
+            :body => empty_response.to_json,
             :status => 200,
             :headers => {'Content-Type' => 'application/json'}
           )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,25 @@
+require 'webmock/rspec'
+
+require 'dotenv'
+Dotenv.load('.env.test')
+
+
+# Requires supporting ruby files with custom matchers and macros, etc,
+# in spec/support/ and its subdirectories.
+Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each {|f| require f}
+
+RSpec.configure do |config|
+  config.mock_with :rspec
+
+  config.raise_errors_for_deprecations!
+
+  # Allow RSpec to run focused specs
+  config.filter_run_including focus: true
+  config.filter_run_excluding broken: true
+  config.filter_run_excluding :bollocksed
+  config.run_all_when_everything_filtered = true
+  config.fail_fast = false
+  config.before focus: true do
+    fail "Hey dummy, don't commit focused specs." if ENV['CI']
+  end
+end

--- a/spec/support/trackjs_helpers.rb
+++ b/spec/support/trackjs_helpers.rb
@@ -9,7 +9,7 @@ module TrackJSHelpers
     application: "r101-frontend",
     id: SecureRandom.uuid
   })
-    trackJsUrl = "https://my.trackjs.com/details/#{params[:id]}"
+    trackjs_url = "https://my.trackjs.com/details/#{params[:id]}"
     params[:message] ||= Faker::Lorem.sentence
 
     return {
@@ -26,28 +26,33 @@ module TrackJSHelpers
       "file" => "https://www.remind.com/classes/sci02",
       "userId" => "11111111",
       "sessionId" => "",
-      "trackJsUrl" => trackJsUrl,
+      "trackJsUrl" => trackjs_url,
       "isStarred" => false
     }
   end
 
-  def trackjs_metadata(totalCount = 0, page = 1, pageSize = 250, hasMore = true)
+  def trackjs_metadata(total_count: 0, page: 1, page_size: 250, has_more: true)
     return {
-      "totalCount" => totalCount,
+      "totalCount" => total_count,
       "page" => page,
-      "size" => pageSize,
-      "hasMore" => hasMore,
+      "size" => page_size,
+      "hasMore" => has_more,
       "trackJsUrl" => "https://my.trackjs.com/recent?"
     }
   end
 
-  def trackjs_response(errors = 0, totalErrors = 0, page = 1, pageSize = 250)
+  def trackjs_response(errors: 0, total_errors: 0, page: 1, page_size: 250)
     data = errors.times.map { trackjs_error }
-    hasMore = (page * pageSize) < totalErrors
+    has_more = (page * page_size) < total_errors
 
     return {
       "data" => data,
-      "metadata" => trackjs_metadata(totalErrors, page, pageSize, hasMore)
+      "metadata" => trackjs_metadata(
+        total_count: total_errors,
+        page: page,
+        page_size: page_size,
+        has_more: has_more
+      )
     }
   end
 end

--- a/spec/support/trackjs_helpers.rb
+++ b/spec/support/trackjs_helpers.rb
@@ -1,0 +1,60 @@
+require 'securerandom'
+
+module TrackJSHelpers
+  def trackjs_error(params = {
+    message: nil,
+    timestamp: Time.now.strftime("%FT%T%:z"),
+    url: "https://www.remind.com",
+    application: "r101-frontend",
+    id: SecureRandom.hex
+  })
+    p "params"
+    pp params
+    trackJsUrl = "https://my.trackjs.com/details/#{params[:id]}"
+    params[:message] ||= "stuff"
+
+    return {
+      "message" => params[:message],
+      "timestamp" => params[:timestamp],
+      "url" => params[:url],
+      "id" => params[:id],
+      "browserName" => "Chrome",
+      "browserVersion" => "49.0.2623",
+      "entry" => "window",
+      "application" => params[:application],
+      "line" => 11,
+      "column" => 13161,
+      "file" => "https://www.remind.com/classes/sci02",
+      "userId" => "11111111",
+      "sessionId" => "",
+      "trackJsUrl" => trackJsUrl,
+      "isStarred" => false
+    }
+  end
+
+  def trackjs_metadata(totalCount = 0, page = 1, pageSize = 250, hasMore = true)
+    return {
+      "totalCount" => totalCount,
+      "page" => page,
+      "size" => pageSize,
+      "hasMore" => hasMore,
+      "trackJsUrl" => "https://my.trackjs.com/recent?"
+    }
+  end
+
+  def trackjs_response(errors = 0, page = 1, pageSize = 250, hasMore = true)
+    data = []
+    errors.times do
+      data.push(trackjs_error)
+    end
+
+    return {
+      "data" => data,
+      "metadata" => trackjs_metadata(data.length, page, pageSize, hasMore)
+    }
+  end
+end
+
+RSpec.configure do |config|
+  config.include TrackJSHelpers
+end

--- a/spec/support/trackjs_helpers.rb
+++ b/spec/support/trackjs_helpers.rb
@@ -44,7 +44,7 @@ module TrackJSHelpers
   def trackjs_response(errors: 0, timestamps: nil, total_errors: 0, page: 1, page_size: 250)
     timestamps = timestamps || errors.times.map { Time.now.utc.strftime("%FT%T%:z") }
     data = errors.times.map do |i|
-      trackjs_error({timestamp: timestamps[i]})
+      trackjs_error(timestamp: timestamps[i])
     end
     has_more = (page * page_size) < total_errors
 

--- a/spec/support/trackjs_helpers.rb
+++ b/spec/support/trackjs_helpers.rb
@@ -2,25 +2,25 @@ require 'securerandom'
 require 'faker'
 
 module TrackJSHelpers
-  def trackjs_error(params = {
+  def trackjs_error(
     message: nil,
-    timestamp: Time.now.strftime("%FT%T%:z"),
+    timestamp: Time.now.utc.strftime("%FT%T%:z"),
     url: "https://www.remind.com",
     application: "r101-frontend",
     id: SecureRandom.uuid
-  })
-    trackjs_url = "https://my.trackjs.com/details/#{params[:id]}"
-    params[:message] ||= Faker::Lorem.sentence
+  )
+    trackjs_url = "https://my.trackjs.com/details/#{id}"
+    message = message || Faker::Lorem.sentence
 
     return {
-      "message" => params[:message],
-      "timestamp" => params[:timestamp],
-      "url" => params[:url],
-      "id" => params[:id],
+      "message" => message,
+      "timestamp" => timestamp,
+      "url" => url,
+      "id" => id,
       "browserName" => "Chrome",
       "browserVersion" => "49.0.2623",
       "entry" => "window",
-      "application" => params[:application],
+      "application" => application,
       "line" => 11,
       "column" => 13161,
       "file" => "https://www.remind.com/classes/sci02",
@@ -41,8 +41,11 @@ module TrackJSHelpers
     }
   end
 
-  def trackjs_response(errors: 0, total_errors: 0, page: 1, page_size: 250)
-    data = errors.times.map { trackjs_error }
+  def trackjs_response(errors: 0, timestamps: nil, total_errors: 0, page: 1, page_size: 250)
+    timestamps = timestamps || errors.times.map { Time.now.utc.strftime("%FT%T%:z") }
+    data = errors.times.map do |i|
+      trackjs_error({timestamp: timestamps[i]})
+    end
     has_more = (page * page_size) < total_errors
 
     return {

--- a/spec/support/trackjs_helpers.rb
+++ b/spec/support/trackjs_helpers.rb
@@ -9,8 +9,6 @@ module TrackJSHelpers
     application: "r101-frontend",
     id: SecureRandom.uuid
   })
-    # p "params"
-    # pp params
     trackJsUrl = "https://my.trackjs.com/details/#{params[:id]}"
     params[:message] ||= Faker::Lorem.sentence
 
@@ -46,8 +44,6 @@ module TrackJSHelpers
   def trackjs_response(errors = 0, totalErrors = 0, page = 1, pageSize = 250)
     data = errors.times.map { trackjs_error }
     hasMore = (page * pageSize) < totalErrors
-    p "trackjs_response calculating hasMore"
-    pp hasMore
 
     return {
       "data" => data,

--- a/spec/support/trackjs_helpers.rb
+++ b/spec/support/trackjs_helpers.rb
@@ -1,4 +1,5 @@
 require 'securerandom'
+require 'faker'
 
 module TrackJSHelpers
   def trackjs_error(params = {
@@ -6,12 +7,12 @@ module TrackJSHelpers
     timestamp: Time.now.strftime("%FT%T%:z"),
     url: "https://www.remind.com",
     application: "r101-frontend",
-    id: SecureRandom.hex
+    id: SecureRandom.uuid
   })
-    p "params"
-    pp params
+    # p "params"
+    # pp params
     trackJsUrl = "https://my.trackjs.com/details/#{params[:id]}"
-    params[:message] ||= "stuff"
+    params[:message] ||= Faker::Lorem.sentence
 
     return {
       "message" => params[:message],
@@ -42,15 +43,15 @@ module TrackJSHelpers
     }
   end
 
-  def trackjs_response(errors = 0, page = 1, pageSize = 250, hasMore = true)
-    data = []
-    errors.times do
-      data.push(trackjs_error)
-    end
+  def trackjs_response(errors = 0, totalErrors = 0, page = 1, pageSize = 250)
+    data = errors.times.map { trackjs_error }
+    hasMore = (page * pageSize) < totalErrors
+    p "trackjs_response calculating hasMore"
+    pp hasMore
 
     return {
       "data" => data,
-      "metadata" => trackjs_metadata(data.length, page, pageSize, hasMore)
+      "metadata" => trackjs_metadata(totalErrors, page, pageSize, hasMore)
     }
   end
 end


### PR DESCRIPTION
This collector uses the TrackJS API to collect metrics about the number of errors triggered in r101-frontend in the previous minute (or whatever time interval `resolution` is set to).

The TrackJS API (http://docs.trackjs.com/data-api/) provides a limited set of different endpoints, and since the smallest time interval you can get data over is by day, we instead use the default `/v2/errors` with a 250 result page size to count the number of new errors seen in the last minute.

The 250 result page size was recommended by one of the TrackJS engineers when I enquired about rate limits for the service. By default the `/v2/errors` endpoint returns all the errors ever, so to avoid trying to count all of these up (and to limit the number of errors counted every time this collector is started) there's a max page limit set. Every minute, the collector will make a request to `/v2/errors`, and count the number of errors returned until either a error previously counted is seen, the collector hits the max page limit, or the collector reads all of the errors returned by the endpoint, which would only happen if < 250 errors are returned in total.

The page size and max number of pages are adjustable, and can be changed once the typical number of errors per minute is known.

Test Plan: This collector was tested by running r101-metrics-collector locally, logging all the errors returned, and ensuring that each of the cases that stop the collector from counting further worked as expected.

